### PR TITLE
goreleaser: Build with CGO enabled

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,3 @@
-builds:
-- env:
-  - CGO_ENABLED=0
 archives:
 - replacements:
     darwin: Darwin


### PR DESCRIPTION
There are differences in the way DNS resolution work when CGO is
disabled that seem to break some systems. I need to look into this
later, but for now lets disable it to keep downloaded binaries working
for everyone.

Fixes #2