### PR TITLE
 Fix help message for switch command

### DIFF
--- a/command/switch_command.go
+++ b/command/switch_command.go
@@ -17,7 +17,7 @@ type SwitchCommand struct {
 
 func (c *SwitchCommand) Help() string {
 	helpText := `
-Usage: keylightctl switch <on|off> [options]
+Usage: keylightctl switch [options] <on|off> 
 
  Switch keylights on and off.
 


### PR DESCRIPTION
Fix help message for switch command

$ keylightctl switch off  --light=192.168.88.2:9123 
==> This command requires (1) argument
==> For additional help try 'keylightctl switch --help'